### PR TITLE
chore: exclude previews from indexing

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -8,6 +8,9 @@ site, this is the place to do it.
     ================================================== -->
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  {% unless site.branch == "main" %}
+  <meta name="robots" content="noindex, nofollow">
+  {% endunless %}
 
   <!-- Mobile Specific Metas ================================================== -->
   <meta name="HandheldFriendly" content="True">


### PR DESCRIPTION
This is a small conditional handler that excludes preview versions from search indexing.
I expect the `main` site to index with Google any day now.
Not time-sensitive, just a small maintenance fix.  Please review/approve.

NOTE: do this PR before an further changes so new preview builds are not generated as indexable