### PR TITLE
add site search

### DIFF
--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -112,6 +112,14 @@ body {
   border-bottom-left-radius: 0.25rem;
 }
 
+.search-body {
+  .usa-search .usa-input {
+    border-color: color("base");
+    border-right-width: 0;
+    border-width: 1px;
+  }
+}
+
 ol.search-results {
   list-style-type: none;
   padding: 0;

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -106,7 +106,6 @@ body {
 
 .usa-search .usa-input {
   border-width: 0;
-  border-radius: 0;
 }
 
 ol.search-results {
@@ -154,6 +153,7 @@ ol.search-results {
   .usa-search .usa-input {
     border-width: 1px;
     border-right-width: 0;
+    border-radius: 0;
   }
 }
 

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -111,7 +111,7 @@ body {
   }
 
   .usa-button {
-    margin-top: units(1);
+    margin-top: units(0);
   }
 }
 

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -203,6 +203,11 @@ ol.search-results {
   }
 }
 
+.usa-nav__secondary {
+  // to reposition search box
+  bottom: 3.9rem;
+}
+
 // BODY
 
 .usa-prose {

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -106,6 +106,9 @@ body {
 
 .usa-search .usa-input {
   border-width: 0;
+  border-radius: 0;
+  border-top-left-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
 }
 
 ol.search-results {
@@ -154,6 +157,8 @@ ol.search-results {
     border-width: 1px;
     border-right-width: 0;
     border-radius: 0;
+    border-top-left-radius: 0.25rem;
+    border-bottom-left-radius: 0.25rem;
   }
 }
 

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -105,6 +105,7 @@ body {
 }
 
 .usa-search .usa-input {
+  -webkit-appearance: none;  // fixes iOS override
   border-width: 0;
   border-radius: 0;
   border-top-left-radius: 0.25rem;

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -119,7 +119,7 @@ ol.search-results {
 
   .search-result-url {
     @include u-font-size("body", "2xs");
-    color: color("base-light");
+    color: color("base");
     //line-height: 1;
   }
 

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -105,7 +105,7 @@ body {
 }
 
 .usa-search .usa-input {
-  -webkit-appearance: none;  // fixes iOS override
+  -webkit-appearance: none; // fixes iOS override
   border-width: 0;
   border-radius: 0;
   border-top-left-radius: 0.25rem;
@@ -123,12 +123,24 @@ ol.search-results {
   .search-result-url {
     @include u-font-size("body", "2xs");
     color: color("base");
-    //line-height: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    a,
+    a:active,
+    a:visited {
+      color: inherit;
+      text-decoration: none;
+    }
   }
 
   .search-result-title {
     @include u-font-size("body", "md");
     font-weight: bold;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .search-result-snippet {
@@ -155,7 +167,7 @@ ol.search-results {
   }
 
   .usa-search .usa-input {
-    -webkit-appearance: none;  // fixes iOS override
+    -webkit-appearance: none; // fixes iOS override
     border-width: 1px;
     border-right-width: 0;
     border-radius: 0;

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -90,10 +90,6 @@ body {
   }
 }
 
-// .usa-header--extended .usa-nav {
-//   border-style: none;
-// }
-
 .usa-header--extended .usa-menu-btn {
   background-color: color("secondary");
   height: 65px;
@@ -103,10 +99,15 @@ body {
 .usa-search .usa-button {
   border-width: 0;
   background-color: color("secondary");
+
+  &:hover {
+    background-color: color("secondary-dark");
+  }
 }
 
 .usa-search .usa-input {
   border-width: 0;
+  border-radius: 0;
 }
 
 // SIDE NAV
@@ -193,6 +194,10 @@ body {
 
 .usa-hero__callout .usa-button {
   background-color: color("secondary");
+
+  &:hover {
+    background-color: color("secondary-dark");
+  }
 }
 
 .usa-summary-box {

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -12,7 +12,7 @@ $theme-color-primary-family: "indigo-cool";
 $theme-color-primary-lightest: false;
 $theme-color-primary-lighter: "#{$theme-color-primary-family}-10";
 $theme-color-primary-light: "#{$theme-color-primary-family}-30";
-$theme-color-primary:  "#{$theme-color-primary-family}-70v"; //"blue-60";
+$theme-color-primary: "#{$theme-color-primary-family}-70v"; //"blue-60";
 $theme-color-primary-vivid: "#{$theme-color-primary-family}-60v";
 $theme-color-primary-dark: "#{$theme-color-primary-family}-80v";
 $theme-color-primary-darker: "#{$theme-color-primary-family}-70v"; //"blue-warm-80v";
@@ -31,7 +31,6 @@ $theme-color-secondary-darkest: false;
 
 $theme-show-notifications: false;
 @import "uswds";
-
 
 // TEMPLATE
 
@@ -66,21 +65,21 @@ body {
 
 // NAV MENUS
 .usa-header--extended .usa-navbar {
-  margin:0;
-  padding:0;
+  margin: 0;
+  padding: 0;
   height: auto;
   max-width: unset;
   border-style: none;
   background-color: color("primary");
 
   .usa-logo {
-    margin:0;
-    height:auto;
-    line-height:0;
+    margin: 0;
+    height: auto;
+    line-height: 0;
     overflow: hidden;
 
     img {
-      max-height:65px;
+      max-height: 65px;
       width: auto;
     }
 
@@ -110,9 +109,32 @@ body {
   border-radius: 0;
 }
 
+ol.search-results {
+  list-style-type: none;
+  padding: 0;
+
+  li {
+    margin-bottom: 1.4em;
+  }
+
+  .search-result-url {
+    @include u-font-size("body", "2xs");
+    color: color("base-light");
+    //line-height: 1;
+  }
+
+  .search-result-title {
+    @include u-font-size("body", "md");
+    font-weight: bold;
+  }
+
+  .search-result-snippet {
+    @include u-font-size("body", "sm");
+  }
+}
+
 // SIDE NAV
 .sidenav-mobile {
-
   @include at-media("desktop") {
     display: none;
   }
@@ -154,12 +176,12 @@ body {
   }
 }
 
-
 // BODY
 
 .usa-prose {
-
-  p, ul li, ol li {
+  p,
+  ul li,
+  ol li {
     max-width: unset;
   }
 }
@@ -172,7 +194,6 @@ body {
 }
 
 .usa-table {
-
   .text-center {
     text-align: center;
   }
@@ -182,13 +203,13 @@ body {
   margin-right: 6px;
 }
 
-.new-tag {  // small red "new"
+.new-tag {
+  // small red "new"
   font-size: 0.7em;
   font-weight: bold;
   color: color("secondary");
   margin-right: 6px;
 }
-
 
 // CONTENT
 
@@ -221,7 +242,7 @@ body {
   a {
     text-decoration: underline;
 
-    &:hover{
+    &:hover {
       color: color("primary");
     }
   }
@@ -230,7 +251,6 @@ body {
 .usa-footer__secondary-section {
   background-color: unset;
 }
-
 
 // default mode hide banner
 .usa-banner__content {

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -154,6 +154,7 @@ ol.search-results {
   }
 
   .usa-search .usa-input {
+    -webkit-appearance: none;  // fixes iOS override
     border-width: 1px;
     border-right-width: 0;
     border-radius: 0;

--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -99,6 +99,16 @@ body {
   height: 65px;
 }
 
+// SEARCH (desktop)
+.usa-search .usa-button {
+  border-width: 0;
+  background-color: color("secondary");
+}
+
+.usa-search .usa-input {
+  border-width: 0;
+}
+
 // SIDE NAV
 .sidenav-mobile {
 
@@ -110,8 +120,17 @@ body {
     margin-top: units(4);
   }
 
-  .usa-button {
+  // search
+  .usa-search .usa-button {
     margin-top: units(0);
+    background-color: color("primary");
+    border-width: 1px;
+    border-left-width: 0;
+  }
+
+  .usa-search .usa-input {
+    border-width: 1px;
+    border-right-width: 0;
   }
 }
 

--- a/_config.yml
+++ b/_config.yml
@@ -27,24 +27,19 @@ ga:
 # 1. Create an account with Search.gov https://search.usa.gov/signup
 # 2. Add a new site.
 # 3. Add your site/affiliate name here.
-#searchgov:
+searchgov:
 
   # You should not change this.
-  #endpoint: https://search.usa.gov
+  endpoint: https://search.usa.gov
 
   # replace this with your search.gov account
-  #affiliate: federalist-uswds-example
+  affiliate: TBD
 
   # replace with your access key
-  #access_key: xX1gtb2RcnLbIYkHAcB6IaTRr4ZfN-p16ofcyUebeko=
+  access_key: TBD
 
   # this renders the results within the page instead of sending to user to search.gov
-  #inline: true
-
-##########################################################################################
-# The values below here are more advanced and should only be
-# changed if you know what they do
-##########################################################################################
+  inline: true
 
 collections:
   pages:
@@ -87,9 +82,6 @@ exclude:
   - node_modules
   - Gemfile
   - Gemfile.lock
-
-  # excluded to disable, but may add back later
-  - search
 
 assets:
   sources:

--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,6 @@ searchgov:
   endpoint: https://search.usa.gov  # You should not change this.
   affiliate: sfw
   access_key: Z9HImZxhu_7RpoY9_2Jd3M1xIofk6orwv-u1aOPnvfI=
-  inline: true  # this renders the results within the page instead of sending to user to search.gov
 
 collections:
   pages:

--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,7 @@ searchgov:
   endpoint: https://search.usa.gov  # You should not change this.
   affiliate: sfw
   access_key: Z9HImZxhu_7RpoY9_2Jd3M1xIofk6orwv-u1aOPnvfI=
+  inline: true  # this renders the results within the page instead of sending to user to search.gov
 
 collections:
   pages:

--- a/_config.yml
+++ b/_config.yml
@@ -23,23 +23,11 @@ ga:
   ua: G-6BVGKEQVMG
 
 # Search.gov configuration
-#
-# 1. Create an account with Search.gov https://search.usa.gov/signup
-# 2. Add a new site.
-# 3. Add your site/affiliate name here.
 searchgov:
-
-  # You should not change this.
-  endpoint: https://search.usa.gov
-
-  # replace this with your search.gov account
-  affiliate: TBD
-
-  # replace with your access key
-  access_key: TBD
-
-  # this renders the results within the page instead of sending to user to search.gov
-  inline: true
+  endpoint: https://search.usa.gov  # You should not change this.
+  affiliate: sfw
+  access_key: Z9HImZxhu_7RpoY9_2Jd3M1xIofk6orwv-u1aOPnvfI=
+  inline: true  # this renders the results within the page instead of sending to user to search.gov
 
 collections:
   pages:

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -35,7 +35,7 @@
         {% endfor %}
       </ul>
       <div class="usa-nav__secondary">
-        {% include searchgov/form.html id="search_form" %}
+        {% include searchgov/form.html uid="search_form_desktop" %}
       </div>
     </div>
   </nav>
@@ -49,7 +49,7 @@
       </ul>
     </div>
     <div class="usa-nav__secondary">
-      {% include searchgov/form.html id="search_form_sidenav" %}
+      {% include searchgov/form.html uid="search_form_mobile" %}
     </div>
 </nav>
 

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -43,14 +43,14 @@
   <!-- mobile view -->
   <nav role="navigation" class="usa-nav site-nav sidenav-mobile">
     <button class="usa-nav__close">{% asset close.svg alt="close" %}</button>
+    <div class="usa-nav__secondary">
+      {% include searchgov/form.html uid="mobile" %}
+    </div>
     <div class="usa-nav__inner">
       <ul class="usa-nav__primary usa-accordion">
         {% include nav/sections.html sections=site.data.nav.mobile %}
       </ul>
     </div>
-    <div class="usa-nav__secondary">
-      {% include searchgov/form.html uid="mobile" %}
-    </div>
-</nav>
+  </nav>
 
 </header>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -35,7 +35,7 @@
         {% endfor %}
       </ul>
       <div class="usa-nav__secondary">
-        {% include searchgov/form.html uid="search_form_desktop" %}
+        {% include searchgov/form.html uid="desktop" %}
       </div>
     </div>
   </nav>
@@ -49,7 +49,7 @@
       </ul>
     </div>
     <div class="usa-nav__secondary">
-      {% include searchgov/form.html uid="search_form_mobile" %}
+      {% include searchgov/form.html uid="mobile" %}
     </div>
 </nav>
 

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -35,7 +35,7 @@
         {% endfor %}
       </ul>
       <div class="usa-nav__secondary">
-        {% include searchgov/form.html %}
+        {% include searchgov/form.html id="search_form" %}
       </div>
     </div>
   </nav>
@@ -49,7 +49,7 @@
       </ul>
     </div>
     <div class="usa-nav__secondary">
-      {% include searchgov/form.html %}
+      {% include searchgov/form.html id="search_form_sidenav" %}
     </div>
 </nav>
 

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -34,9 +34,9 @@
         {% endunless %}
         {% endfor %}
       </ul>
-      <!-- <div class="usa-nav__secondary">
+      <div class="usa-nav__secondary">
         {% include searchgov/form.html searchgov=site.searchgov %}
-      </div> -->
+      </div>
     </div>
   </nav>
 
@@ -48,6 +48,9 @@
         {% include nav/sections.html sections=site.data.nav.mobile %}
       </ul>
     </div>
-  </nav>
+    <div class="usa-nav__secondary">
+      {% include searchgov/form.html searchgov=site.searchgov %}
+    </div>
+</nav>
 
 </header>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -35,7 +35,7 @@
         {% endfor %}
       </ul>
       <div class="usa-nav__secondary">
-        {% include searchgov/form.html searchgov=site.searchgov %}
+        {% include searchgov/form.html %}
       </div>
     </div>
   </nav>
@@ -49,7 +49,7 @@
       </ul>
     </div>
     <div class="usa-nav__secondary">
-      {% include searchgov/form.html searchgov=site.searchgov %}
+      {% include searchgov/form.html %}
     </div>
 </nav>
 

--- a/_includes/searchgov/form.html
+++ b/_includes/searchgov/form.html
@@ -15,7 +15,7 @@
   
     <div role="search">
       <label class="usa-sr-only" for="extended-search-field-small">Search small</label>
-      <input class="usa-input usagov-search-autocomplete" id="extended-search-field-small" type="search" name="query" autocomplete="off">
+      <input class="usa-input usagov-search-autocomplete" id="{{include.id}}-extended-search-field-small" type="search" name="query" autocomplete="off">
       <button class="usa-button" type="submit"><span class="usa-sr-only">Search</span></button>
     </div>
   </form>

--- a/_includes/searchgov/form.html
+++ b/_includes/searchgov/form.html
@@ -4,7 +4,7 @@
 
 {% if site.searchgov %}
   {% if site.searchgov.inline == true %}
-    <form id="{{include.uid}}" class="usa-search usa-search--small" action="{{site.url}}/search/" accept-charset="UTF-8" method="get">
+    <form id="{{include.uid}}" class="usa-search usa-search--small" action="{{site.baseurl}}/search/" accept-charset="UTF-8" method="get">
   {% else %}
     <form id="{{include.uid}}" class="usa-search usa-search--small" action="{{site.searchgov.endpoint}}/search" accept-charset="UTF-8" method="get">
   {% endif %}

--- a/_includes/searchgov/form.html
+++ b/_includes/searchgov/form.html
@@ -4,9 +4,9 @@
 
 {% if site.searchgov %}
   {% if site.searchgov.inline == true %}
-    <form id="{{include.id}}" class="usa-search usa-search--small" action="{{site.url}}/search/" accept-charset="UTF-8" method="get">
+    <form id="{{include.uid}}" class="usa-search usa-search--small" action="{{site.url}}/search/" accept-charset="UTF-8" method="get">
   {% else %}
-    <form id="{{include.id}}" class="usa-search usa-search--small" action="{{site.searchgov.endpoint}}/search" accept-charset="UTF-8" method="get">
+    <form id="{{include.uid}}" class="usa-search usa-search--small" action="{{site.searchgov.endpoint}}/search" accept-charset="UTF-8" method="get">
   {% endif %}
     
   
@@ -14,8 +14,8 @@
     <input name="affiliate" type="hidden" value="{{site.searchgov.affiliate}}" />
   
     <div role="search">
-      <label class="usa-sr-only" for="extended-search-field-small">Search small</label>
-      <input class="usa-input usagov-search-autocomplete" id="{{include.id}}-extended-search-field-small" type="search" name="query" autocomplete="off">
+      <label class="usa-sr-only" for="{{include.uid}}-extended-search-field-small">Search small</label>
+      <input class="usa-input usagov-search-autocomplete" id="{{include.uid}}-extended-search-field-small" type="search" name="query" autocomplete="off">
       <button class="usa-button" type="submit"><span class="usa-sr-only">Search</span></button>
     </div>
   </form>

--- a/_includes/searchgov/form.html
+++ b/_includes/searchgov/form.html
@@ -1,22 +1,17 @@
-{% comment %} 
-  This will redirect the results to /search template which will handle the js loading
+{% comment %}
+This will redirect the results to /search template which will handle the js loading
 {% endcomment %}
 
-{% if include.searchgov %}
-  {% if include.searchgov.inline == true %}
-    <form id="search_form" class="usa-search usa-search--small" action="{{site.baseurl}}/search/" accept-charset="UTF-8" method="get">
-  {% else %}
-    <form id="search_form" class="usa-search usa-search--small" action="{{include.searchgov.endpoint}}/search" accept-charset="UTF-8" method="get">
-  {% endif %}
-    
-  
-    <input name="utf8" type="hidden" value="&#x2713;" />
-    <input name="affiliate" type="hidden" value="{{include.searchgov.affiliate}}" />
-  
-    <div role="search">
-      <label class="usa-sr-only" for="extended-search-field-small">Search small</label>
-      <input class="usa-input usagov-search-autocomplete" id="extended-search-field-small" type="search" name="query" autocomplete="off">
-      <button class="usa-button" type="submit"><span class="usa-sr-only">Search</span></button>
-    </div>
-  </form>
+{% if site.searchgov %}
+<form id="search_form" class="usa-search usa-search--small" action="{{site.baseurl}}/search/" accept-charset="UTF-8" method="get">
+  <input name="utf8" type="hidden" value="&#x2713;" />
+  <input name="affiliate" type="hidden" value="{{site.searchgov.affiliate}}" />
+
+  <div role="search">
+    <label class="usa-sr-only" for="extended-search-field-small">Search small</label>
+    <input class="usa-input usagov-search-autocomplete" id="extended-search-field-small" type="search" name="query"
+      autocomplete="off">
+    <button class="usa-button" type="submit"><span class="usa-sr-only">Search</span></button>
+  </div>
+</form>
 {% endif %}

--- a/_includes/searchgov/form.html
+++ b/_includes/searchgov/form.html
@@ -1,17 +1,22 @@
-{% comment %}
-This will redirect the results to /search template which will handle the js loading
+{% comment %} 
+  This will redirect the results to /search template which will handle the js loading
 {% endcomment %}
 
 {% if site.searchgov %}
-<form id="search_form" class="usa-search usa-search--small" action="{{site.baseurl}}/search/" accept-charset="UTF-8" method="get">
-  <input name="utf8" type="hidden" value="&#x2713;" />
-  <input name="affiliate" type="hidden" value="{{site.searchgov.affiliate}}" />
-
-  <div role="search">
-    <label class="usa-sr-only" for="extended-search-field-small">Search small</label>
-    <input class="usa-input usagov-search-autocomplete" id="extended-search-field-small" type="search" name="query"
-      autocomplete="off">
-    <button class="usa-button" type="submit"><span class="usa-sr-only">Search</span></button>
-  </div>
-</form>
+  {% if site.searchgov.inline == true %}
+    <form id="{{include.id}}" class="usa-search usa-search--small" action="{{site.url}}/search/" accept-charset="UTF-8" method="get">
+  {% else %}
+    <form id="{{include.id}}" class="usa-search usa-search--small" action="{{site.searchgov.endpoint}}/search" accept-charset="UTF-8" method="get">
+  {% endif %}
+    
+  
+    <input name="utf8" type="hidden" value="&#x2713;" />
+    <input name="affiliate" type="hidden" value="{{site.searchgov.affiliate}}" />
+  
+    <div role="search">
+      <label class="usa-sr-only" for="extended-search-field-small">Search small</label>
+      <input class="usa-input usagov-search-autocomplete" id="extended-search-field-small" type="search" name="query" autocomplete="off">
+      <button class="usa-button" type="submit"><span class="usa-sr-only">Search</span></button>
+    </div>
+  </form>
 {% endif %}

--- a/search/index.html
+++ b/search/index.html
@@ -27,7 +27,9 @@ sitemap: false
       render_result(`
           <li>
             <div class="search-result-url">
-              ${posts.web.results[item]['url']} 
+              <a href="${posts.web.results[item]['url']}">
+              ${posts.web.results[item]['url']}
+              </a>
             </div>
             <div class="search-result-title">
               <a href="${posts.web.results[item]['url']}">
@@ -50,7 +52,7 @@ sitemap: false
   }).finally(function (e) {
 
     if (document.getElementById('search-results').childNodes.length == 0) {
-      render_result(`<h4>No results found</h4>`, false)
+      render_result(`<h4 style="padding-left:10px;">No results found</h4>`, false)
     }
 
   })

--- a/search/index.html
+++ b/search/index.html
@@ -18,11 +18,19 @@ sitemap: false
   }
 
 
-  Object.keys(params).forEach(key => searchEndpoint.searchParams.append(key, params[key]))
+  Object.keys(params)
+  .forEach(key => searchEndpoint.searchParams.append(key, params[key]))
 
-  fetch(searchEndpoint).then(function (res) {
+  fetch(searchEndpoint)
+  .then(function (res) {
     return res.json()
-  }).then(function (posts) {
+  })
+  .then(function (posts) {
+
+    // render search box with prior search term
+    document.getElementById('results-extended-search-field-small').value = params.query;
+
+    // render results
     for (item in posts.web.results) {
       render_result(`
           <li>
@@ -51,10 +59,10 @@ sitemap: false
     console.log('parsing failed', ex);
   }).finally(function (e) {
 
+    // no results scenario
     if (document.getElementById('search-results').childNodes.length == 0) {
       render_result(`<h4 style="padding-left:10px;">No results found</h4>`, false)
     }
-
   })
 
   function render_result(content, append = true) {
@@ -65,8 +73,10 @@ sitemap: false
 //]]>
 </script>
 
-
 {% if site.searchgov %}
+<div id="search-box" class="search-body margin-bottom-3">
+  {% include searchgov/form.html uid="results" %}
+</div>
 <h1 style="margin-top:0 !important;">Search Results</h1>
 <ol id="search-results" class="search-results"></ol>
 {% else %}

--- a/search/index.html
+++ b/search/index.html
@@ -2,6 +2,7 @@
 permalink: /search/
 layout: page
 title: Search
+sitemap: false
 ---
 
 

--- a/search/index.html
+++ b/search/index.html
@@ -7,66 +7,63 @@ sitemap: false
 
 
 <script>
-//<![CDATA[
+  //<![CDATA[
 
-  var urlParams = new URLSearchParams(window.location.search);    
+  var urlParams = new URLSearchParams(window.location.search);
   var searchEndpoint = new URL("{{site.searchgov.endpoint}}/api/v2/search/i14y");
-  params = { affiliate: "{{site.searchgov.affiliate}}", access_key: "{{site.searchgov.access_key}}", query: urlParams.get('query') }
-  
-  
+  params = {
+    affiliate: "{{site.searchgov.affiliate}}",
+    access_key: "{{site.searchgov.access_key}}",
+    query: urlParams.get('query')
+  }
+
+
   Object.keys(params).forEach(key => searchEndpoint.searchParams.append(key, params[key]))
 
-  fetch(searchEndpoint).then(function(res) {
-      return res.json()
-    }).then(function(posts) {
-      for (item in posts.web.results){
-        render_result(`
-          <li class="padding-bottom-5 margin-top-4 usa-prose border-bottom-05 border-base-lightest">
-            <b class="title"><a href="${posts.web.results[item]['url']}">${posts.web.results[item]['title']}</a></b>
-            <div> ${posts.web.results[item]['snippet'].replace(/\uE000/g, '<span class="bg-yellow">').replace(/\uE001/g, '</span>')} </div>
+  fetch(searchEndpoint).then(function (res) {
+    return res.json()
+  }).then(function (posts) {
+    for (item in posts.web.results) {
+      render_result(`
+          <li>
+            <div class="search-result-url">
+              ${posts.web.results[item]['url']} 
+            </div>
+            <div class="search-result-title">
+              <a href="${posts.web.results[item]['url']}">
+                ${posts.web.results[item]['title'].replace(/\uE000/g, '').replace(/\uE001/g, '')}
+              </a>
+            </div>
+            <div class="search-result-snippet">
+              ${posts.web.results[item]['snippet'].replace(/\uE000/g, '<strong>').replace(/\uE001/g, '</strong>')} 
+            </div>
           </li>
           `, true)
-        
-      }
-    }).catch(function(ex) {
-      console.log('parsing failed', ex);
-    }).finally(function(e){
-    
-      if(document.getElementById('search-results').childNodes.length == 0){
-        render_result(`<h4 class="title">No results found</h4>`, false)
-      }
-          
-    })
-    
-    function render_result(content, append = true){
-      const previous = document.getElementById('search-results').innerHTML;
-      document.getElementById('search-results').innerHTML = (append == true) ? previous + content : content;
     }
+  }).catch(function (ex) {
+    console.log('parsing failed', ex);
+  }).finally(function (e) {
+
+    if (document.getElementById('search-results').childNodes.length == 0) {
+      render_result(`<h4>No results found</h4>`, false)
+    }
+
+  })
+
+  function render_result(content, append = true) {
+    const previous = document.getElementById('search-results').innerHTML;
+    document.getElementById('search-results').innerHTML = (append == true) ? previous + content : content;
+  }
 
 //]]>
 </script>
 
 
 {% if site.searchgov %}
-  <h1>Search Results</h1>
-  <ol id="search-results"></ol>
-
-  {% if site.searchgov.affiliate == "federalist-uswds-example" %}
-    <div class="usa-alert usa-alert--info">
-      <div class="usa-alert__body">
-        This is an example. You will need to configure your site with search.gov to see the correct search results. To do this:
-        <ol>
-          <li>Create an account with Search.gov at <a href="https://search.usa.gov/signup">https://search.usa.gov/signup</a></li>
-          <li>Go to the "Activate" section and get "API Access Key"</a></li>          
-          <li>Open <code>_config.yml</code> and look for <code>searchgov</code> fields</li>
-          <li>Add your <code>affiliate</code> and <code>access_key</code></li>
-          <li>Your results will not show up immediately. Make sure you follow <a href="https://search.gov/manual/searchgov-for-federalist.html">instructions to index your site</a>.</li> 
-        </ol>
-      </div>
-    </div>
-  {% endif %}  
+<h1 style="margin-top:0 !important;">Search Results</h1>
+<ol id="search-results" class="search-results"></ol>
 {% else %}
-  <script>
-    window.location = "/";
-  </script>
+<script>
+  window.location = "/";
+</script>
 {% endif %}

--- a/search/index.html
+++ b/search/index.html
@@ -31,11 +31,16 @@ sitemap: false
             </div>
             <div class="search-result-title">
               <a href="${posts.web.results[item]['url']}">
-                ${posts.web.results[item]['title'].replace(/\uE000/g, '').replace(/\uE001/g, '')}
+                ${posts.web.results[item]['title']
+                  .replace(' | {{site.title}}', '')
+                  .replace(/\uE000/g, '')
+                  .replace(/\uE001/g, '')}
               </a>
             </div>
             <div class="search-result-snippet">
-              ${posts.web.results[item]['snippet'].replace(/\uE000/g, '<strong>').replace(/\uE001/g, '</strong>')} 
+              ${posts.web.results[item]['snippet']
+                .replace(/\uE000/g, '<strong>')
+                .replace(/\uE001/g, '</strong>')} 
             </div>
           </li>
           `, true)


### PR DESCRIPTION
Adds basic site search-bar and inline search results from Search.gov - #64 

To do:

- [x] Review design and layout (internal)
- [x] Work with Search.gov to fully enable integration
- [x] Remove “ | Safer Federal Workforce” suffix from search result titles
- [x] Consider ellipses for offscreen URLs in results
- [x] Consider re-displaying populated search box at top of results page for better context, revision of search term
- [x] Review / feedback incorporation / final approvals with SFWTF