### PR TITLE
add redirect to new exception form

### DIFF
--- a/downloads/RELIGIOUS REQUEST FORM - 20211004 - MH508.pdf.html
+++ b/downloads/RELIGIOUS REQUEST FORM - 20211004 - MH508.pdf.html
@@ -1,7 +1,9 @@
 ---
+sitemap: false
 ---
 <!DOCTYPE html>
 <meta charset="utf-8">
+<meta name="robots" content="noindex">
 <title>Redirecting...</title>
 {% assign redirect_url = "/downloads/RELIGIOUS REQUEST FORM_FINAL REVIEW_20211003 10.29 11am.pdf" | prepend: site.baseurl %}
 <link rel="canonical" href="{{ redirect_url }}">

--- a/downloads/RELIGIOUS REQUEST FORM - 20211004 - MH508.pdf.html
+++ b/downloads/RELIGIOUS REQUEST FORM - 20211004 - MH508.pdf.html
@@ -1,0 +1,12 @@
+---
+---
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting...</title>
+{% assign redirect_url = "/downloads/RELIGIOUS REQUEST FORM_FINAL REVIEW_20211003 10.29 11am.pdf" | prepend: site.baseurl %}
+<link rel="canonical" href="{{ redirect_url }}">
+<meta http-equiv="refresh" content="0; url={{ redirect_url }}">
+<h1>Redirecting...</h1>
+<p>This form has been updated.  You are being redirected to the new form.</p>
+<a href="{{ redirect_url }}">Click here if you are not redirected.</a>
+<script>location="{{ redirect_url }}"</script>


### PR DESCRIPTION
This is a small maintenance improvement to redirect links from the old religious exception form to the new one.

The old form:
/downloads/RELIGIOUS REQUEST FORM - 20211004 - MH508.pdf